### PR TITLE
Allow executing on windows 7.

### DIFF
--- a/neo/engine/external/imgui/examples/imgui_impl_win32.h
+++ b/neo/engine/external/imgui/examples/imgui_impl_win32.h
@@ -16,8 +16,8 @@ IMGUI_IMPL_API void     ImGui_ImplWin32_NewFrame();
 
 // Configuration
 // - Disable gamepad support or linking with xinput.lib
-//#define IMGUI_IMPL_WIN32_DISABLE_GAMEPAD
-//#define IMGUI_IMPL_WIN32_DISABLE_LINKING_XINPUT
+#define IMGUI_IMPL_WIN32_DISABLE_GAMEPAD
+#define IMGUI_IMPL_WIN32_DISABLE_LINKING_XINPUT
 
 // Win32 message handler your application need to call.
 // - Intentionally commented out in a '#if 0' block to avoid dragging dependencies on <windows.h> from this helper.


### PR DESCRIPTION
Disable gamepad support andlinking with xinput.lib in imgui. This causes an issue with running on Windows 7 after compiling on a recent Windows SDK.